### PR TITLE
Configure maximum logging level

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1677,9 +1677,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "mach"
@@ -3150,6 +3150,7 @@ dependencies = [
  "anyhow",
  "clap",
  "env_logger 0.10.2",
+ "log",
  "prettytable-rs",
  "reqwest",
  "wws-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ path = "src/main.rs"
 [dependencies]
 actix-web = { workspace = true }
 anyhow = "1.0.66"
+log = "0.4.21"
 env_logger = "0.10.0"
 clap = { version = "4.0.10", features = ["derive"] }
 prettytable-rs = "0.10.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,15 +9,15 @@ use crate::utils::runtimes::install_missing_runtimes;
 use clap::Parser;
 use commands::main::Main;
 use commands::runtimes::RuntimesCommands;
+use log::LevelFilter;
 use std::io::{Error, ErrorKind};
 use std::path::PathBuf;
-use std::str::FromStr;
 use std::process::exit;
+use std::str::FromStr;
 use wws_config::Config;
 use wws_project::{identify_type, prepare_project, ProjectType};
 use wws_router::Routes;
 use wws_server::{serve, ServeOptions};
-use log::LevelFilter;
 
 // Arguments
 #[derive(Parser, Debug)]
@@ -84,16 +84,14 @@ async fn main() -> std::io::Result<()> {
     let args = Args::parse();
 
     match std::env::var("RUST_LOG") {
-        Ok(_) => {},
-        Err(_) => {
-            match args.log_level {
-                LevelFilter::Off => std::env::set_var("RUST_LOG", ""),
-                LevelFilter::Error => std::env::set_var("RUST_LOG", "actix_web=error"),
-                LevelFilter::Warn => std::env::set_var("RUST_LOG", "actix_web=warn"),
-                LevelFilter::Info => std::env::set_var("RUST_LOG", "actix_web=info"),
-                LevelFilter::Debug => std::env::set_var("RUST_LOG", "actix_web=debug"),
-                LevelFilter::Trace => std::env::set_var("RUST_LOG", "actix_web=trace"),
-            }
+        Ok(_) => {}
+        Err(_) => match args.log_level {
+            LevelFilter::Off => std::env::set_var("RUST_LOG", ""),
+            LevelFilter::Error => std::env::set_var("RUST_LOG", "actix_web=error"),
+            LevelFilter::Warn => std::env::set_var("RUST_LOG", "actix_web=warn"),
+            LevelFilter::Info => std::env::set_var("RUST_LOG", "actix_web=info"),
+            LevelFilter::Debug => std::env::set_var("RUST_LOG", "actix_web=debug"),
+            LevelFilter::Trace => std::env::set_var("RUST_LOG", "actix_web=trace"),
         },
     }
 
@@ -203,14 +201,14 @@ async fn main() -> std::io::Result<()> {
                 args.port,
                 route.path,
                 route.handler.display()
-                );
+            );
         }
 
         if args.enable_panel {
             println!(
                 "🎛️  The admin panel is available at http://{}:{}/_panel/",
                 &args.hostname, args.port
-                );
+            );
         }
 
         let server = serve(ServeOptions {
@@ -222,12 +220,12 @@ async fn main() -> std::io::Result<()> {
             cors_origins: args.cors,
         })
         .await
-            .map_err(|err| Error::new(ErrorKind::AddrInUse, err))?;
+        .map_err(|err| Error::new(ErrorKind::AddrInUse, err))?;
 
         println!(
             "🚀 Start serving requests at http://{}:{}\n",
             args.hostname, args.port
-            );
+        );
 
         // Run the server
         server.await


### PR DESCRIPTION
Fixes #253.

Adds a `--log-level` option to configure the `actix_web` logs that can be one of the valid [log::LevelFilter](https://docs.rs/log/latest/log/enum.LevelFilter.html) options (off, error, warn, info, debug, trace). It will default to `info` if none is specified.

This is my first Rust-only PR. I'm sure some things can be more elegant, so please let me know 😄 